### PR TITLE
Change price type to int64

### DIFF
--- a/market/market.proto
+++ b/market/market.proto
@@ -24,7 +24,7 @@ message User {
   int32 port = 4;
 
   // price per mb for a file
-  int32 price = 5;
+  int64 price = 5;
 }
 
 message FileRequest {

--- a/test_client/main.go
+++ b/test_client/main.go
@@ -59,7 +59,7 @@ func main() {
 	userID := fmt.Sprintf("user%d", rand.Intn(10000))
 
 	fmt.Print("Enter a price for supplying files: ")
-	var price int32
+	var price int64
 	_, err = fmt.Scanln(&price)
 	if err != nil {
 		fmt.Println("Error: ", err)


### PR DESCRIPTION
According to the Bitcoin specification, the price type (labelled "value" in the
source) is declared as "int64_t", so we make it int64:
https://en.bitcoin.it/wiki/Protocol_documentation#tx